### PR TITLE
General fixes

### DIFF
--- a/autoload/you_are_here.vim
+++ b/autoload/you_are_here.vim
@@ -146,15 +146,11 @@ endfunction
 " credit: https://vim.fandom.com/wiki/Windo_and_restore_current_window
 
 " Just like windo, but restore the current window when done.
-function! WinDo(command)
+function! s:WinDo(command)
   let currwin = winnr()
   execute 'windo ' . a:command
   execute currwin . 'wincmd w'
 endfunction
-com! -nargs=+ -complete=command Windo call WinDo(<q-args>)
-
-" Just like Windo, but disable all autocommands for super fast processing.
-com! -nargs=+ -complete=command Windofast noautocmd call WinDo(<q-args>)
 
 function! s:UpdatePopups()
   for p in s:youarehere_popups
@@ -168,7 +164,7 @@ function! s:YouAreHere()
     call <SID>ClosePopups()
     return
   endif
-  Windofast call <SID>OpenPopup(winnr())
+  noautocmd call s:WinDo("call <SID>OpenPopup(winnr())")
 endfunction
 
 function! you_are_here#Update()


### PR DESCRIPTION
This PR applies some fixes to issues or potential issues with the plugin.

First, the global variables used as settings are set at the beginning of the autoloaded file, which means if I put, for instance, this in my `.vimrc`, it won't apply:

``` vim
let g:youarehere_padding = [0, 0, 0, 0]
```

The PR puts if-clauses around the variables to check if they already exist before setting their default values.

The other change I've made is to remove the `WinDo` function and the `WinDo` and `Windofast` commands. I see that you've taken them from the Vim wiki, which makes sense, but if you're distributing them as a plugin, it's best to make them local. The function, as defined, is global, which could be a problem if somebody created a function with the same name but with a different implementation -- maybe they took it from the same tip and later modified it. The plugin would overwrite it when it's invoked and it could be difficult to debug.

Turning the function script-local is good enough. There's no way to turn the commands script-local, but honestly, you don't need them. Commands are most useful as a user interface (space-delimited args, completion) -- in a script context, it's common to use functions instead.

A few more things I'd consider:
- Usually, the autoload directory is only used for the functions that implement the plugin, and a `plugin/you_are_here.vim` file would hold the settings and mappings. What you've done also works, and it loads less, so that's fine. Still, setting a few global variables and highlight groups is not going to slow Vim startup a lot, so I'd consider organizing things this way regardless.
- The `WinDo` function is quite simple, and only used in one place, so instead of giving it a generic "command" to execute, you could just inline it and replace `execute 'windo ' . a:command` with a less indirect `noautocmd windo call s:OpenPopup(winnr())`. But that seems like a matter of preference.