### PR TITLE
Add compatibility checks and show clear error messages in incompatible Vim versions

### DIFF
--- a/autoload/you_are_here.vim
+++ b/autoload/you_are_here.vim
@@ -1,3 +1,8 @@
+if v:version < 802
+  echoerr 'you-are-here plugin requires Vim 8.2 or higher. Aborting.'
+  finish
+endif
+
 if !exists('g:youarehere_border')
   let g:youarehere_border = [1, 1, 1, 1]
 endif

--- a/autoload/you_are_here.vim
+++ b/autoload/you_are_here.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_you_are_here')
+  finish
+endif
+let g:loaded_you_are_here = 1
+
 if v:version < 802
   echoerr 'you-are-here plugin requires Vim 8.2 or higher. Aborting.'
   finish

--- a/autoload/you_are_here.vim
+++ b/autoload/you_are_here.vim
@@ -99,7 +99,7 @@ function! s:ClosePopups()
   endfor
   call <SID>ResetPopups()
 
-  if (s:timeout)
+  if has('timers') && (s:timeout)
     call timer_stop(s:timeout)
   endif
 endfunction
@@ -190,6 +190,11 @@ function! you_are_here#Toggle()
 endfunction
 
 function! you_are_here#ToggleFor(duration)
+  if !has('timers')
+    echoerr 'Calling you_are_here#ToggleFor() requires Vim built with +timers.'
+    return
+  endif
+
   call <SID>YouAreHere()
 
   let s:timeout = timer_start(a:duration, {-> <SID>ClosePopups()})


### PR DESCRIPTION
This PR adds some compatibility checks to prevent Vim from spamming with unclear error messages, specifically:

* `you-are-here` uses `popup_create()`, which seems to be introduced in Vim versions somewhere between `8.1` and `8.2`, and `win_screenpos()`, which appeared somewhere between `8.0` and `8.1`. This causes Vim to show lots of garbage errors when trying to use `you-are-here` on older but still widely deployed systems like CentOS 7 (runs Vim `7.4`).
* the `ToggleFor()` feature, introduced in #9, requires Vim to be built with `+timers` feature, but given that this function is not essential for the core functionality of `you-are-here`, it deserves a separate feature gate with a meaningful error message.