### PR TITLE
Fix screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # you-are-here.vim
 📌 See the filenames of your vim splits in easy-to-read popups, switch windows seamlessly
 
-![you-are-here.vim screenshot](https://github.com/bignimbus/you-are-here.vim/blob/master/assets/you-are-here.png)
+![you-are-here.vim screenshot](https://github.com/bignimbus/you-are-here.vim/blob/main/assets/you-are-here.png)
 
 ---
 


### PR DESCRIPTION
Hey there! The screenshot's link in the README expected the branch to be `master` despite the only branch being `main`.